### PR TITLE
Add node color support from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Python project for plotting undirected graph(s) from .csv file
+Python project for plotting undirected graph(s) from .csv file.
+
+The CSV file should contain columns `Parent` and `Child` describing
+edges. Optionally it may also include `BackgroundColor` and `FontColor`
+columns for styling individual nodes. When these columns are missing
+the default black text on white background is used.

--- a/graf2.py
+++ b/graf2.py
@@ -9,15 +9,46 @@ cyto.load_extra_layouts()
 # === Загрузка CSV ===
 df = pd.read_csv("hierarchy.csv")
 
+# Use default colors if the CSV does not provide them
+DEFAULT_BG = "#ffffff"
+DEFAULT_FONT = "#000000"
+
+# Ensure optional columns exist
+if 'BackgroundColor' not in df.columns:
+    df['BackgroundColor'] = DEFAULT_BG
+if 'FontColor' not in df.columns:
+    df['FontColor'] = DEFAULT_FONT
+
 # === Построение графа ===
 df['Node'] = df['Parent'].astype(str)
 df['Target'] = df['Child'].astype(str)
 
-# Уникальные узлы
-all_nodes = pd.unique(df[['Node', 'Target']].values.ravel('K'))
 
-# Создание узлов
-nodes = [{"data": {"id": n, "label": n}} for n in all_nodes]
+# Уникальные узлы с учетом стилей
+all_nodes = pd.unique(df[['Node', 'Target']].values.ravel('K'))
+node_styles = {n: {"font_color": DEFAULT_FONT, "background_color": DEFAULT_BG}
+               for n in all_nodes}
+
+# Apply colors from CSV (assumed to describe the child node)
+for _, row in df.iterrows():
+    child = str(row['Child'])
+    node_styles[child] = {
+        "font_color": row.get('FontColor', DEFAULT_FONT),
+        "background_color": row.get('BackgroundColor', DEFAULT_BG)
+    }
+
+# Создание узлов с учетом цветов
+nodes = [
+    {
+        "data": {
+            "id": n,
+            "label": n,
+            "font_color": style["font_color"],
+            "background_color": style["background_color"],
+        }
+    }
+    for n, style in node_styles.items()
+]
 
 # Создание рёбер
 edges = [{"data": {"source": row['Parent'], "target": row['Child']}} for _, row in df.iterrows()]
@@ -39,11 +70,11 @@ app.layout = html.Div([
                     "selector": "node",
                     "style": {
                         "shape": "rectangle",
-                        "background-color": "#ffffff",
+                        "background-color": "data(background_color)",
                         "border-color": "#000000",
                         "border-width": 2,
                         "label": "data(label)",
-                        "color": "#000000",
+                        "color": "data(font_color)",
                         "font-size": "12px",
                         "text-valign": "center",
                         "text-halign": "center",


### PR DESCRIPTION
## Summary
- allow optional `BackgroundColor` and `FontColor` columns
- set node style from CSV data with defaults
- document optional columns in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d4b6a36c8332a73c9229cf27ed88